### PR TITLE
[subSystem_KARMA] clean by remove sName and update documentation

### DIFF
--- a/src/libraries/icubclient/include/icubclient/subsystems/subSystem_KARMA.h
+++ b/src/libraries/icubclient/include/icubclient/subsystems/subSystem_KARMA.h
@@ -125,15 +125,13 @@ public:
      * @param theta: angle to define pushing left (0) or right (180)
      * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
      * @param options to be passed to KARMA
-     * @param sName: name of object to push
      * @return true in case of success release, false otherwise
      */
     bool pushAside(const std::string &objName,
                    const yarp::sig::Vector &objCenter, const double &targetPosY,
                    const double &theta,
                    const std::string &armType = "selectable",
-                   const yarp::os::Bottle &options = yarp::os::Bottle(),
-                   const std::string &sName = "target");
+                   const yarp::os::Bottle &options = yarp::os::Bottle());
 
     /**
      * @brief pushFront (KARMA): push an object to a certain location along x-axis of robot RoF
@@ -142,42 +140,37 @@ public:
      * @param targetPosXFront: x coordinate of location to push object to
      * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
      * @param options to be passed to KARMA
-     * @param sName: name of object to push
      * @return true in case of success release, false otherwise
      */
     bool pushFront(const std::string &objName,
                    const yarp::sig::Vector &objCenter, const double &targetPosXFront,
                    const std::string &armType = "selectable",
-                   const yarp::os::Bottle &options = yarp::os::Bottle(),
-                   const std::string &sName = "target");
+                   const yarp::os::Bottle &options = yarp::os::Bottle());
 
     /**
-     * @brief push (KARMA): push to certain position, along a direction
+     * @brief push (KARMA): push to certain position, along a defined direction
      * @param targetCenter: position to push to.
      * @param theta: angle between the y-axis (in robot FoR) and starting position of push action, defines the direction of push action
      * @param radius: radius of the circle with center at @see targetCenter
      * @param options to be passed to KARMA
-     * @param sName: name of object to push
      * @return true in case of success release, false otherwise
      */
     bool push(const yarp::sig::Vector &targetCenter, const double theta, const double radius,
-              const yarp::os::Bottle &options = yarp::os::Bottle(),
-              const std::string &sName="target");
+              const yarp::os::Bottle &options = yarp::os::Bottle());
 
     /**
      * @brief pullBack (KARMA): pull an object to a certain location along x-axis of robot RoF
+     * @param objName: name of object to pull
      * @param objCenter: coordinate of object
      * @param targetPosXBack: x coordinate of location to pull object to
      * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
      * @param options to be passed to KARMA
-     * @param sName: name of object to pull
      * @return true in case of success release, false otherwise
      */
     bool pullBack(const std::string &objName,
                   const yarp::sig::Vector &objCenter, const double &targetPosXBack,
                   const std::string &armType = "selectable",
-                  const yarp::os::Bottle &options = yarp::os::Bottle(),
-                  const std::string &sName="target");
+                  const yarp::os::Bottle &options = yarp::os::Bottle());
     /**
      * @brief draw (KARMA): draw action, along the positive direction of the x-axis (in robot FoR)
      * @param targetCenter: center of a circle
@@ -185,16 +178,14 @@ public:
      * @param radius: radius of the circle with center at @see targetCenter
      * @param dist: moving distance of draw action
      * @param options to be passed to KARMA
-     * @param sName: name of object to push
      * @return true in case of success release, false otherwise
      */
     bool draw(const yarp::sig::Vector &targetCenter, const double theta,
               const double radius, const double dist,
-              const yarp::os::Bottle &options = yarp::os::Bottle(),
-              const std::string &sName="target");
+              const yarp::os::Bottle &options = yarp::os::Bottle());
 
     /**
-     * @brief vdraw (KARMA): draw action, along the positive direction of the x-axis (in robot FoR)
+     * @brief vdraw (KARMA): virtual draw action, along the positive direction of the x-axis (in robot FoR)
      * @param targetCenter: center of a circle
      * @param theta: angle between the y-axis (in robot FoR) and starting position of draw action.
      * @param radius: radius of the circle with center at @see targetCenter
@@ -205,9 +196,8 @@ public:
      */
     bool vdraw(const std::string &targetName,
                const yarp::sig::Vector &targetCenter, const double theta,
-              const double radius, const double dist,
-              const yarp::os::Bottle &options = yarp::os::Bottle(),
-              const std::string &sName="target");
+               const double radius, const double dist,
+               const yarp::os::Bottle &options = yarp::os::Bottle());
 
     bool openCartesianClient();
 

--- a/src/libraries/icubclient/src/subsystems/subSystem_KARMA.cpp
+++ b/src/libraries/icubclient/src/subsystems/subSystem_KARMA.cpp
@@ -263,10 +263,10 @@ void icubclient::SubSystem_KARMA::chooseArmAuto()
 }
 
 bool icubclient::SubSystem_KARMA::pushAside(const std::string &objName,
-                                                const yarp::sig::Vector &objCenter, const double &targetPosY,
-                                                const double &theta,
-                                                const std::string &armType,
-                                                const yarp::os::Bottle &options, const std::string &sName)
+                                            const yarp::sig::Vector &objCenter, const double &targetPosY,
+                                            const double &theta,
+                                            const std::string &armType,
+                                            const yarp::os::Bottle &options)
 {
     // Calculate the pushing distance (radius) for push with Karma
     Vector object = objCenter;
@@ -294,7 +294,7 @@ bool icubclient::SubSystem_KARMA::pushAside(const std::string &objName,
         armChoose = chooseArm(armType);
 
     // Call push (no calibration)
-    bool pushSucceed = push(targetCenter,theta,radius + actionOffset,options,sName);
+    bool pushSucceed = push(targetCenter,theta,radius + actionOffset,options);
 
     //if (pushSucceed)
     //    returnArmSafely(armType);
@@ -306,9 +306,9 @@ bool icubclient::SubSystem_KARMA::pushAside(const std::string &objName,
 }
 
 bool icubclient::SubSystem_KARMA::pushFront(const std::string &objName,
-                                                const yarp::sig::Vector &objCenter, const double &targetPosXFront,
-                                                const std::string &armType,
-                                                const yarp::os::Bottle &options, const std::string &sName)
+                                            const yarp::sig::Vector &objCenter, const double &targetPosXFront,
+                                            const std::string &armType,
+                                            const yarp::os::Bottle &options)
 {
     // Calculate the pushing distance (radius) for push with Karma
     Vector object = objCenter;
@@ -336,7 +336,7 @@ bool icubclient::SubSystem_KARMA::pushFront(const std::string &objName,
         armChoose = chooseArm(armType);
 
     // Call push (no calibration)
-    bool pushSucceed = push(targetCenter,-90,radius + actionOffset,options,sName);
+    bool pushSucceed = push(targetCenter,-90,radius + actionOffset,options);
 
     //if (pushSucceed)
     //    returnArmSafely(armType);
@@ -348,8 +348,8 @@ bool icubclient::SubSystem_KARMA::pushFront(const std::string &objName,
 }
 
 bool icubclient::SubSystem_KARMA::push(const yarp::sig::Vector &targetCenter,
-                                           const double theta, const double radius,
-                                           const yarp::os::Bottle &options, const std::string &sName)
+                                       const double theta, const double radius,
+                                       const yarp::os::Bottle &options)
 {
     yarp::os::Bottle bCmd;
     bCmd.addVocab(yarp::os::Vocab::encode("push"));
@@ -373,9 +373,9 @@ bool icubclient::SubSystem_KARMA::push(const yarp::sig::Vector &targetCenter,
 }
 
 bool icubclient::SubSystem_KARMA::pullBack(const std::string &objName,
-                                               const yarp::sig::Vector &objCenter, const double &targetPosXBack,
-                                               const std::string &armType,
-                                               const yarp::os::Bottle &options, const std::string &sName)
+                                           const yarp::sig::Vector &objCenter, const double &targetPosXBack,
+                                           const std::string &armType,
+                                           const yarp::os::Bottle &options)
 {
     // Calculate the pulling distance (dist) for pull with Karma
     Vector object = objCenter;
@@ -403,7 +403,7 @@ bool icubclient::SubSystem_KARMA::pullBack(const std::string &objName,
         armChoose = chooseArm(armType);
 
     // Call draw (no calibration)
-    bool drawSucceed = draw(targetCenter,90,actionOffset,dist + actionOffset,options,sName);
+    bool drawSucceed = draw(targetCenter,90,actionOffset,dist + actionOffset,options);
 
     //if (drawSucceed)
     //    returnArmSafely(armType);
@@ -415,9 +415,8 @@ bool icubclient::SubSystem_KARMA::pullBack(const std::string &objName,
 }
 
 bool icubclient::SubSystem_KARMA::draw(const yarp::sig::Vector &targetCenter,
-                                           const double theta, const double radius,
-                                           const double dist,
-                                           const yarp::os::Bottle &options, const std::string &sName)
+                                       const double theta, const double radius,
+                                       const double dist, const yarp::os::Bottle &options)
 {
     yarp::os::Bottle bCmd;
     bCmd.addVocab(yarp::os::Vocab::encode("draw"));
@@ -440,10 +439,10 @@ bool icubclient::SubSystem_KARMA::draw(const yarp::sig::Vector &targetCenter,
 }
 
 bool icubclient::SubSystem_KARMA::vdraw(const std::string &targetName,
-                                            const yarp::sig::Vector &targetCenter,
-                                            const double theta, const double radius,
-                                            const double dist,
-                                            const yarp::os::Bottle &options, const std::string &sName)
+                                        const yarp::sig::Vector &targetCenter,
+                                        const double theta, const double radius,
+                                        const double dist,
+                                        const yarp::os::Bottle &options)
 {
     yarp::os::Bottle bCmd;
     bCmd.addVocab(yarp::os::Vocab::encode("vdraw"));


### PR DESCRIPTION
The `PR` is to provide a clean `subSystem_KARMA` without redundant arguments in methods.

cc @Tobias-Fischer 

Cheers,
Phuong 