### PR TITLE
[icubClient] clean KARMA related push/pull methods

### DIFF
--- a/src/libraries/icubclient/include/icubclient/clients/icubClient.h
+++ b/src/libraries/icubclient/include/icubclient/clients/icubClient.h
@@ -276,61 +276,6 @@ namespace icubclient{
             const yarp::os::Bottle &options = yarp::os::Bottle());
 
         /**
-         * @brief pushKarmaLeft: push an object to left side, this wrapper simplify pure push action of KARMA
-         * See the SubSystem_KARMA::pushAside documentation for more details.
-         * @param objName: name of object to push (used for iolReachingCalibration)
-         * @param objCenter: coordinate of object's center
-         * @param targetPosYLeft: Y coordinate of object to push to
-         * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
-         * @param options: options to be passed to Karma
-         * @return true in case of success release, false otherwise
-         */
-        bool pushKarmaLeft(const std::string &objName, const yarp::sig::Vector &objCenter, const double &targetPosYLeft,
-            const std::string &armType = "selectable",
-            const yarp::os::Bottle &options = yarp::os::Bottle());
-
-        /**
-         * @brief pushKarmaRight: push an object to right side, this wrapper simplify pure push action of KARMA
-         * See the SubSystem_KARMA::pushAside documentation for more details.
-         * @param objName: name of object to push (used for iolReachingCalibration)
-         * @param objCenter: coordinate of object's center
-         * @param targetPosYRight: Y coordinate of object to push to
-         * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
-         * @param options: options to be passed to Karma
-         * @return true in case of success release, false otherwise
-         */
-        bool pushKarmaRight(const std::string &objName, const yarp::sig::Vector &objCenter, const double &targetPosYRight,
-            const std::string &armType = "selectable", const yarp::os::Bottle &options = yarp::os::Bottle());
-
-        /**
-         * @brief pushKarmaFront: push an object to front, this wrapper simplify pure push action of KARMA
-         * See the SubSystem_KARMA::pushFront documentation for more details.
-         * @param objName: name of object to push (used for iolReachingCalibration)
-         * @param objCenter: coordinate of object's center
-         * @param targetPosXFront: X coordinate of object to push to
-         * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
-         * @param options: options to be passed to Karma
-         * @return true in case of success release, false otherwise
-         */
-        bool pushKarmaFront(const std::string &objName, const yarp::sig::Vector &objCenter, const double &targetPosXFront,
-            const std::string &armType = "selectable",
-            const yarp::os::Bottle &options = yarp::os::Bottle());
-
-        /**
-         * @brief pullKarmaBack: pull an object back, this wrapper simplify pure draw action of KARMA
-         * See the SubSystem_KARMA::pullBack documentation for more details.
-         * @param objCenter: coordinate of object's center
-         * @param targetPosXBack: X coordinate of object to pull back
-         * @param armType: "left" or "right" arm to conduct action, otherwise arm will be chosen by KARMA
-         * @param options: options to be passed to Karma
-         * @param objName: name of object to pull (used for iolReachingCalibration)
-         * @return true in case of success release, false otherwise
-         */
-        bool pullKarmaBack(const std::string &objName, const yarp::sig::Vector &objCenter, const double &targetPosXBack,
-            const std::string &armType = "selectable",
-            const yarp::os::Bottle &options = yarp::os::Bottle());
-
-        /**
         * @brief pushKarma (KARMA): push to certain position, along a direction
         * See the SubSystem_KARMA::push documentation for more details.
         * @param targetCenter: position to push to.

--- a/src/libraries/icubclient/src/clients/icubClient_KARMArelated.cpp
+++ b/src/libraries/icubclient/src/clients/icubClient_KARMArelated.cpp
@@ -31,6 +31,13 @@ bool ICubClient::pushKarmaLeft(const std::string &objName, const double &targetP
     const std::string &armType,
     const yarp::os::Bottle &options)
 {
+    SubSystem_KARMA *karma = getKARMA();
+    if (karma == NULL)
+    {
+        yError() << "[iCubClient] Called pushKarmaLeft() but KARMA subsystem is not available.";
+        return false;
+    }
+
     if (opc->isConnected())
     {
         Entity *target = opc->getEntity(objName, true);
@@ -49,61 +56,17 @@ bool ICubClient::pushKarmaLeft(const std::string &objName, const double &targetP
 
         yInfo("[icubClient pushKarmaLeft] object %s position from OPC (no calibration): %s", oTarget->name().c_str(),
             oTarget->m_ego_position.toString().c_str());
-        return pushKarmaLeft(objName, oTarget->m_ego_position, targetPosYLeft, armType, options);
+        return karma->pushAside(objName, oTarget->m_ego_position, targetPosYLeft, 0, armType, options);
     }
     else
     {
         yWarning() << "[iCubClient] There is no OPC connection";
         return false;
     }
-}
-
-bool ICubClient::pushKarmaLeft(const std::string &objName, const yarp::sig::Vector &objCenter, const double &targetPosYLeft,
-    const std::string &armType,
-    const yarp::os::Bottle &options)
-{
-    SubSystem_KARMA *karma = getKARMA();
-    if (karma == NULL)
-    {
-        yError() << "[iCubClient] Called pushKarmaLeft() but KARMA subsystem is not available.";
-        return false;
-    }
-    return karma->pushAside(objName,objCenter, targetPosYLeft, 0, armType, options);
 }
 
 // Right push
 bool ICubClient::pushKarmaRight(const std::string &objName, const double &targetPosYRight,
-    const std::string &armType,
-    const yarp::os::Bottle &options)
-{
-    if (opc->isConnected())
-    {
-        Entity *target = opc->getEntity(objName, true);
-        if (!target->isType(ICUBCLIENT_OPC_ENTITY_OBJECT))
-        {
-            yWarning() << "[iCubClient] Called pushKarmaLeft() on a unallowed entity: \"" << objName << "\"";
-            return false;
-        }
-
-        Object *oTarget = dynamic_cast<Object*>(target);
-        if (oTarget->m_present != 1.0)
-        {
-            yWarning() << "[iCubClient] Called pushKarmaLeft() on an unavailable entity: \"" << objName << "\"";
-            return false;
-        }
-
-        yInfo("[icubClient pushKarmaRight] object %s position from OPC (no calibration): %s", oTarget->name().c_str(),
-            oTarget->m_ego_position.toString().c_str());
-        return pushKarmaRight(objName, oTarget->m_ego_position, targetPosYRight, armType, options);
-    }
-    else
-    {
-        yWarning() << "[iCubClient] There is no OPC connection";
-        return false;
-    }
-}
-
-bool ICubClient::pushKarmaRight(const std::string &objName, const yarp::sig::Vector &objCenter, const double &targetPosYRight,
     const std::string &armType,
     const yarp::os::Bottle &options)
 {
@@ -113,7 +76,32 @@ bool ICubClient::pushKarmaRight(const std::string &objName, const yarp::sig::Vec
         yError() << "[iCubClient] Called pushKarmaRight() but KARMA subsystem is not available.";
         return false;
     }
-    return karma->pushAside(objName, objCenter, targetPosYRight, 180, armType, options);
+
+    if (opc->isConnected())
+    {
+        Entity *target = opc->getEntity(objName, true);
+        if (!target->isType(ICUBCLIENT_OPC_ENTITY_OBJECT))
+        {
+            yWarning() << "[iCubClient] Called pushKarmaRight() on a unallowed entity: \"" << objName << "\"";
+            return false;
+        }
+
+        Object *oTarget = dynamic_cast<Object*>(target);
+        if (oTarget->m_present != 1.0)
+        {
+            yWarning() << "[iCubClient] Called pushKarmaRight() on an unavailable entity: \"" << objName << "\"";
+            return false;
+        }
+
+        yInfo("[icubClient pushKarmaRight] object %s position from OPC (no calibration): %s", oTarget->name().c_str(),
+            oTarget->m_ego_position.toString().c_str());
+        return karma->pushAside(objName, oTarget->m_ego_position, targetPosYRight, 180, armType, options);
+    }
+    else
+    {
+        yWarning() << "[iCubClient] There is no OPC connection";
+        return false;
+    }
 }
 
 // Front push
@@ -121,6 +109,13 @@ bool ICubClient::pushKarmaFront(const std::string &objName, const double &target
     const std::string &armType,
     const yarp::os::Bottle &options)
 {
+    SubSystem_KARMA *karma = getKARMA();
+    if (karma == NULL)
+    {
+        yError() << "[iCubClient] Called pushKarmaFront() but KARMA subsystem is not available.";
+        return false;
+    }
+
     if (opc->isConnected())
     {
         Entity *target = opc->getEntity(objName, true);
@@ -139,26 +134,13 @@ bool ICubClient::pushKarmaFront(const std::string &objName, const double &target
 
         yInfo("[icubClient pushKarmaFront] object %s position from OPC (no calibration): %s", oTarget->name().c_str(),
             oTarget->m_ego_position.toString().c_str());
-        return pushKarmaFront(objName, oTarget->m_ego_position, targetPosXFront, armType, options);
+        return karma->pushFront(objName, oTarget->m_ego_position, targetPosXFront, armType, options);
     }
     else
     {
         yWarning() << "[iCubClient] There is no OPC connection";
         return false;
     }
-}
-
-bool ICubClient::pushKarmaFront(const std::string& objName, const yarp::sig::Vector &objCenter, const double &targetPosXFront,
-    const std::string &armType,
-    const yarp::os::Bottle &options)
-{
-    SubSystem_KARMA *karma = getKARMA();
-    if (karma == NULL)
-    {
-        yError() << "[iCubClient] Called pushKarmaFront() but KARMA subsystem is not available.";
-        return false;
-    }
-    return karma->pushFront(objName, objCenter, targetPosXFront, armType, options);
 }
 
 // Pure push in KARMA
@@ -179,6 +161,13 @@ bool ICubClient::pullKarmaBack(const std::string &objName, const double &targetP
     const std::string &armType,
     const yarp::os::Bottle &options)
 {
+    SubSystem_KARMA *karma = getKARMA();
+    if (karma == NULL)
+    {
+        yError() << "[iCubClient] Called pullKarmaBack() but KARMA subsystem is not available.";
+        return false;
+    }
+
     if (opc->isConnected())
     {
         Entity *target = opc->getEntity(objName, true);
@@ -197,7 +186,7 @@ bool ICubClient::pullKarmaBack(const std::string &objName, const double &targetP
 
         yInfo("[icubClient pullKarmaBack] object %s position from OPC (no calibration): %s", oTarget->name().c_str(),
             oTarget->m_ego_position.toString().c_str());
-        return pullKarmaBack(objName, oTarget->m_ego_position, targetPosXBack, armType, options);
+        return karma->pullBack(objName, oTarget->m_ego_position, targetPosXBack, armType, options);
     }
     else
     {
@@ -205,20 +194,6 @@ bool ICubClient::pullKarmaBack(const std::string &objName, const double &targetP
         return false;
     }
 }
-
-bool ICubClient::pullKarmaBack(const std::string &objName,const yarp::sig::Vector &objCenter, const double &targetPosXBack,
-    const std::string &armType,
-    const yarp::os::Bottle &options)
-{
-    SubSystem_KARMA *karma = getKARMA();
-    if (karma == NULL)
-    {
-        yError() << "[iCubClient] Called pullKarmaBack() but KARMA subsystem is not available.";
-        return false;
-    }
-    return karma->pullBack(objName,objCenter, targetPosXBack, armType, options);
-}
-
 
 // Pure pull (draw) in KARMA
 bool ICubClient::drawKarma(const yarp::sig::Vector &targetCenter, const double &theta,


### PR DESCRIPTION
This `PR` to remove the redundancy of `karmaWYSIWYD` wrappers in `icubClient`, which require both `object name` and `object center`. After this `PR`, only methods which require only the `object name` are kept.

@Tobias-Fischer please have look!

Cheers,
Phuong